### PR TITLE
Auth without configuration yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,7 @@ from timeguard_supplymaster import Client
 
 client = Client()
 client.refresh_devices()
-for device in tg.devices:
-  print(device.name, device.id)
-  for program in device.programs:
-    print(program.id, program.name)
-    print(program.time_slots)
+
 ```
 
 For more examples see the examples folder.

--- a/examples/auth_no_config_file.py
+++ b/examples/auth_no_config_file.py
@@ -1,0 +1,13 @@
+# GitHub: joemadd3n
+# Contact: joe@madden.cloud
+# Date: 08/03/2021
+
+
+from timeguard_supplymaster import Client
+
+# An alternative to using the .yaml file for configuation is to over-ride the config-file by passing "use_config_file=False" and 
+# specifying your api username and password
+client = Client(use_config_file=False, api_username='your_api_username', api_password='your_api_password')
+
+client.refresh_devices()
+

--- a/timeguard_supplymaster/client.py
+++ b/timeguard_supplymaster/client.py
@@ -23,11 +23,21 @@ class Client:
   EVERYDAY = { 'Mon': True, 'Tue': True, 'Wed': True, 'Thu': True, 'Fri': True, 'Sat': True, 'Sun': True}
   NEVER = { 'Mon': False, 'Tue': False, 'Wed': False, 'Thu': False, 'Fri': False, 'Sat': False, 'Sun': False}
 
-  def __init__(self, config_path=f'{str(Path.home())}/.timeguard.yaml', cache_folder=f'{os.getcwd()}/cache', quiet=False):
-    self.config = self.read_config(config_path)
-    self.validate_config()
-    self.cache_folder = cache_folder
-    os.makedirs(cache_folder, exist_ok=True)
+  def __init__(self, config_path=f'{str(Path.home())}/.timeguard.yaml',use_config_file=True, cache_folder=f'{os.getcwd()}/cache', quiet=False, 
+                api_username='', api_password=''):
+
+    if not(use_config_file):
+      self.config['username'] = api_username
+      self.config['password'] = api_password
+      self.config['use_cache'] = False
+
+    else:
+
+      self.config = self.read_config(config_path)
+      self.validate_config()
+      self.cache_folder = cache_folder
+      os.makedirs(cache_folder, exist_ok=True)
+    
     self.quiet = quiet
 
   def _log(self, *msg, usePP = False):
@@ -81,5 +91,7 @@ class Client:
     self.token = response_json['message']['user']['token']
     self.user_id = response_json['message']['user']['id']
     for device in response_json['message']['wifi_box']:
-      self.devices.append(Device(self, device))
+      if device['online'] == '1':
+        self.devices.append(Device(self, device))
+      else: self._log(device['name'], 'is offline')
     return self.devices


### PR DESCRIPTION
Hi Richard,

Change 1:

User is able to authenticate against the API without using the YAML file for configuration, this is done when initiating the Client()

```
client = Client(use_config_file=False, api_username='your_api_username', api_password='your_api_password')
```

Change 2:
The Client module fails if a device is listed on the API but is offline, I have added in logic to skip over offline devices and write to the log that the device is offline.

Change 3:
Readme file, the example given doesn't work, maybe it's just me but I've removed it to avoid confusion to others, unless of course you check it and it works, in which case I apologise profusely!

```
for device in tg.devices:
  print(device.name, device.id)
  for program in device.programs:
    print(program.id, program.name)
    print(program.time_slots)
```

Thanks,
Joe.
